### PR TITLE
Security headers created twice

### DIFF
--- a/httpheader.php
+++ b/httpheader.php
@@ -97,8 +97,10 @@ class PlgSystemHttpHeader extends CMSPlugin
 	public function onAfterInitialise()
 	{
 		// Set the default header when they are enabled
-		$this->setStaticHeaders();
-
+		if ((int) $this->params->get('write_static_headers', 0) == 0)
+		{ 
+			$this->setStaticHeaders();
+		}
 		// Handle CSP Header configuration
 		$cspOptions = (int) $this->params->get('contentsecuritypolicy', 0);
 


### PR DESCRIPTION
Hi,

Thank you for this plugin.

When "write header to config file" is set, security headers are created twice : once in .htaccess/web.config file and once in html code.

When looking at your website with https://securityheaders.com/, everything is ok except warnings about duplicate headers.

I'm working with Joomla 3.9.5 which includes https://github.com/joomla/joomla-cms/pull/24429

Pascal